### PR TITLE
Use keys as constant instead of editing the file

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,15 @@ When [embedding the User Dashboard](https://freemius.com/help/documentation/user
 ## Installation
 
 1. Download the plugin.
-2. Open the main plugin's file `freemius-wordpress-sso.php`, scroll to the bottom, and replace `<STORE_ID>`, `<DEVELOPER_ID>`, and `<DEVELOPER_SECRET_KEY>` with your details. You can get your _developer ID_ and _secret key_ in the **My Profile** page, and your _store ID_ in the **My Store** page. Both pages are accessible from the top-right menu.
+2. Open your WordPress installation's `wp-config.php` file and add the following lines at the end, replacing the placeholders with your actual credentials:
+
+```
+define( 'FREEMIUS_STORE_ID', '<STORE_ID>' );
+define( 'FREEMIUS_DEVELOPER_ID', '<DEVELOPER_ID>' );
+define( 'FREEMIUS_SECRET_KEY', '<DEVELOPER_SECRET_KEY>' );
+```
+
+You can get your _developer ID_ and _secret key_ in the **My Profile** page, and your _store ID_ in the **My Store** page. Both pages are accessible from the top-right menu.
+
 3. Upload and activate the plugin.
 4. Done! Users will be able to login with their Freemius credentials.

--- a/freemius-wordpress-sso.php
+++ b/freemius-wordpress-sso.php
@@ -451,7 +451,7 @@
     }
 
     FS_SSO::instance()->init(
-        '<STORE_ID>',
-        '<DEVELOPER_ID>',
-        '<DEVELOPER_SECRET_KEY>'
+        FREEMIUS_STORE_ID,
+        FREEMIUS_DEVELOPER_ID,
+        FREEMIUS_SECRET_KEY
     );

--- a/readme.txt
+++ b/readme.txt
@@ -18,7 +18,14 @@ When embedding the User Dashboard (https://github.com/Freemius/freemius-users-da
 == Installation ==
 
 1. Download the plugin.
-2. Open the main plugin's file `freemius-wordpress-sso.php`, scroll to the bottom, and replace `<STORE_ID>`, `<DEVELOPER_ID>`, and `<DEVELOPER_SECRET_KEY>` with your details. You can get your _developer ID_ and _secret key_ in the **My Profile** page, and your _store ID_ in the **My Store** page. Both pages are accessible from the top-right menu.
+2. Open your WordPress installation's `wp-config.php` file and add the following lines at the end, replacing the placeholders with your actual credentials:
+
+define( 'FREEMIUS_STORE_ID', '<STORE_ID>' );
+define( 'FREEMIUS_DEVELOPER_ID', '<DEVELOPER_ID>' );
+define( 'FREEMIUS_SECRET_KEY', '<DEVELOPER_SECRET_KEY>' );
+
+You can get your _developer ID_ and _secret key_ in the **My Profile** page, and your _store ID_ in the **My Store** page. Both pages are accessible from the top-right menu.
+
 3. Upload and activate the plugin.
 4. Done! Users will be able to login with their Freemius credentials.
 


### PR DESCRIPTION
Instead of editing the plugin's main file, add the required keys as constant for e.g. in wp-config.php.
